### PR TITLE
Adds custom cache suppport to the redis lock

### DIFF
--- a/viewflow/contrib/redis.py
+++ b/viewflow/contrib/redis.py
@@ -2,7 +2,7 @@ import time
 import random
 from contextlib import contextmanager
 
-from django.core.cache import cache
+from django.core.cache import cache as default_cache
 from django.db import transaction
 
 from viewflow.exceptions import FlowLockFailed
@@ -14,30 +14,52 @@ except ImportError:
     raise ImportError('django-redis required')
 
 
-def redis_lock(flow, attempts=5, expires=120):
+class RedisLock:
     """
-    Task lock based redis locks implemented in ``django-redis``.
+    Task lock based on redis' cache capabilities.
+
+    Example::
+
+        class MyFlow(Flow):
+            lock_impl = RedisLock(cache=caches['locks'])
+
+    The example uses a different cache. The default cache
+    is Django's ``default`` cache configuration.
+
+    ..note::
+        This lock requires a ``django-redis`` cache backend.
+
     """
 
-    @contextmanager
-    def lock(flow_cls, process_pk):
-        key = 'django-viewflow-lock-{}/{}'.format(flow_cls._meta.namespace, process_pk)
+    def __init__(self, *, cache=default_cache):
+        self.cache = cache
 
-        for i in range(attempts):
-            lock = cache.lock(key, timeout=expires)
-            stored = lock.acquire(blocking=False)
-            if stored:
-                break
-            if i != attempts - 1:
-                sleep_time = (((i + 1) * random.random()) + 2 ** i) / 2.5
-                time.sleep(sleep_time)
-        else:
-            raise FlowLockFailed('Lock failed for {}'.format(flow_cls))
+    def __call__(self, flow, attempts=5, expires=120):
+        cache = self.cache
 
-        try:
-            with transaction.atomic():
-                yield
-        finally:
-            lock.release()
+        @contextmanager
+        def lock(flow_cls, process_pk):
+            key = 'django-viewflow-lock-{}/{}'.format(flow_cls._meta.namespace, process_pk)
 
-    return lock
+            for i in range(attempts):
+                lock = cache.lock(key, timeout=expires)
+                stored = lock.acquire(blocking=False)
+                if stored:
+                    break
+                if i != attempts - 1:
+                    sleep_time = (((i + 1) * random.random()) + 2 ** i) / 2.5
+                    time.sleep(sleep_time)
+            else:
+                raise FlowLockFailed('Lock failed for {}'.format(flow_cls))
+
+            try:
+                with transaction.atomic():
+                    yield
+            finally:
+                lock.release()
+
+        return lock
+
+
+redis_lock = RedisLock()
+"""Task lock requires the default cache config to use a ``django-redis`` cache backend."""


### PR DESCRIPTION
The default cache might not bet setup to use django-redis or
the locks are stored in a sperate database to avoid the
locks from being accidently cleared.