### PR TITLE
Fixed task_finished in FlowTaskTest

### DIFF
--- a/tests/test_flow_signal.py
+++ b/tests/test_flow_signal.py
@@ -1,9 +1,14 @@
+from django.conf.urls import include, url
+from django.contrib.auth.models import User
 from django.dispatch import Signal
 from django.test import TestCase
 
-from viewflow import flow
+from viewflow import flow, views
 from viewflow.base import Flow, this
 from viewflow.flow.signal import Receiver
+from viewflow.signals import task_finished
+from viewflow.test import FlowTest
+from viewflow.views import ProcessView
 
 
 class Test(TestCase):
@@ -12,8 +17,15 @@ class Test(TestCase):
         process = SignalFlow.process_cls.objects.get()
         task_test_signal.send(sender=self, process=process)
 
+        user = User.objects.create(username="test")
+
+        with FlowTest(SignalFlow) as flow:
+            flow.Task(SignalFlow.task).User("test").Execute() \
+                .Assert(lambda t: t.flow_task == SignalFlow.task,
+                    "Returned task should be the executed one.")
+
         tasks = process.task_set.all()
-        self.assertEqual(3, tasks.count())
+        self.assertEqual(4, tasks.count())
         self.assertTrue(all(task.finished is not None for task in tasks))
 
     def test_signal_ignore_activation(self):
@@ -50,7 +62,21 @@ def signal_task(activation, **kwargs):
 
 class SignalFlow(Flow):
     start = flow.StartSignal(start_test_signal, create_flow).Next(this.signal_task)
-    signal_task = flow.Signal(task_test_signal, signal_task).Next(this.end)
+    signal_task = flow.Signal(task_test_signal, signal_task).Next(this.task)
+    task = flow.View(ProcessView, fields=[]).Next(this.end)
+    end = flow.End()
+
+
+def create_other_flow(activation, **kwargs):
+    process = kwargs['process']
+    task = kwargs['task']
+    if task.flow_task == SignalFlow.task:
+        activation.prepare()
+        activation.done()
+
+
+class OtherFlow(Flow):
+    start_signal = flow.StartSignal(task_finished, create_other_flow, sender=SignalFlow).Next(this.end)
     end = flow.End()
 
 
@@ -72,3 +98,21 @@ class IgnorableSignalFlow(Flow):
     signal_task = flow.Signal(ignorable_test_signal, IgnorableReceiver) \
         .Next(this.end)
     end = flow.End()
+
+
+urlpatterns = [
+    url(r'^signal/', include([
+        SignalFlow.instance.urls,
+        url('^details/(?P<process_pk>\d+)/$', views.ProcessDetailView.as_view(), name='details'),
+    ], namespace=SignalFlow.instance.namespace), {'flow_cls': SignalFlow}),
+]
+
+
+try:
+    from django.test import override_settings
+    Test = override_settings(ROOT_URLCONF=__name__)(Test)
+except ImportError:
+    """
+    django 1.6
+    """
+    Test.urls = __name__

--- a/viewflow/test.py
+++ b/viewflow/test.py
@@ -8,7 +8,7 @@ with FlowTest(RestrictedUserFlow) as flow_test:
         .Assert(p: p.owner='yyy')
 
     with patch('web.service'):
-        flow_test.Task(Flow.job),Execute()
+        flow_test.Task(Flow.job).Execute()
 
     flow_test.User('aaa').Task(Flow.confirm).Execute({'confirm': 1})
 
@@ -104,13 +104,12 @@ class FlowTaskTest(object):
         self._task = None
 
     def task_finished(self, sender, **kwargs):
+        """
+        First finished task is ours
+        """
         if self._task is None:
-            """
-            First finished task is ours
-            """
-            assert self.flow_task == kwargs['task'].flow_task
-
-            self._task = kwargs['task']
+            if self.flow_task == kwargs['task'].flow_task:
+                self._task = kwargs['task']
 
     @cached_property
     def process(self):
@@ -153,7 +152,7 @@ class FlowTaskTest(object):
         """
         Assert task or process.
 
-        It is possible to assert ether the task or related process by choosing
+        It is possible to assert either the task or related process by choosing
         a different arg name for the assertion function.
 
         Example::


### PR DESCRIPTION
@kmmbvnr When testing got the following error.

  File ".../viewflow/viewflow/test.py", line 111, in task_finished
    assert self.flow_task == kwargs['task'].flow_task
AssertionError


The case occurred when testing a the original flow with a certain task.

While having an other flow to start with a StartSignal like this:
```start_signal = flow.StartSignal(task_finished, create_other_flow, sender=SignalFlow).Next(this.end)```


Also fixed two little typos in the documentation