### PR TITLE
request.REQUEST deprecated, removed in Django 1.9

### DIFF
--- a/demo/website.py
+++ b/demo/website.py
@@ -13,7 +13,7 @@ def users(request):
 def login_as(request):
     user = None
 
-    user_pk = request.REQUEST.get('user_pk', None)
+    user_pk = request.GET.get('user_pk', None)
     if user_pk:
         try:
             user = User.objects.get(pk=user_pk)


### PR DESCRIPTION
running the demo with `django==1.9` will fail as the `request.REQUEST` was removed