### PR TITLE
Prevent multiple calls to yield.

### DIFF
--- a/viewflow/lock.py
+++ b/viewflow/lock.py
@@ -15,10 +15,6 @@ class DatabaseLockError(Exception):
     pass
 
 
-class ProcessDoesNotExist(Exception):
-    pass
-
-
 def no_lock(flow):
     """
     No pessimistic locking, just execute flow task in transaction.
@@ -46,7 +42,7 @@ def select_for_update_lock(flow, nowait=True, attempts=5):
                     process = flow_class.process_class._default_manager.filter(pk=process_pk)
                     try:
                         if not process.select_for_update(nowait=nowait).exists():
-                            raise ProcessDoesNotExist
+                            raise DatabaseLockError
                     except DatabaseError:
                         raise DatabaseLockError
                     yield


### PR DESCRIPTION
We experienced issues with background jobs returning tracebacks ending with `RuntimeError: generator didn't stop after throw()`.

It's our understanding that the problem lies in the overly general `except DatabaseError` statement within the `transaction.atomic()` block. If code being executed after the yield has already occurred raises a `DatabaseError` it's possible for the retry code to execute, therefore causing yield to be called more than once - which is not allowed.