### PR TITLE
Updating link URL to go to the new introduction page.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ django forms and views code.
 Documentation
 =============
 
-Read the documentation at the `http://docs.viewflow.io/ <http://docs.viewflow.io/introduction.html>`_
+Read the documentation at the `http://docs.viewflow.io/ <http://docs.viewflow.io/>`_
 
 License
 =======


### PR DESCRIPTION
Current link goes to http://docs.viewflow.io/introduction.html which no longer exists (404s).
Looks like that content has moved to the main page http://docs.viewflow.io/