### PR TITLE
Explicit 'on_delete' for ForeignKey/OneToOneField

### DIFF
--- a/demo/customnode/migrations/0001_initial.py
+++ b/demo/customnode/migrations/0001_initial.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 from django.conf import settings
+import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
@@ -24,7 +25,8 @@ class Migration(migrations.Migration):
             name='DynamicSplitProcess',
             fields=[
                 ('process_ptr', models.OneToOneField(to='viewflow.Process', primary_key=True,
-                                                     parent_link=True, serialize=False, auto_created=True)),
+                                                     parent_link=True, serialize=False, auto_created=True,
+                                                     on_delete=django.db.models.deletion.CASCADE)),
                 ('question', models.CharField(max_length=50)),
                 ('split_count', models.IntegerField(default=0)),
             ],
@@ -36,11 +38,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='decision',
             name='process',
-            field=models.ForeignKey(to='customnode.DynamicSplitProcess'),
+            field=models.ForeignKey(to='customnode.DynamicSplitProcess', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='decision',
             name='user',
-            field=models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
     ]

--- a/demo/customnode/models.py
+++ b/demo/customnode/models.py
@@ -9,6 +9,7 @@ class DynamicSplitProcess(Process):
 
 
 class Decision(models.Model):
-    process = models.ForeignKey(DynamicSplitProcess)
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
+    process = models.ForeignKey(DynamicSplitProcess, on_delete=models.CASCADE)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True, on_delete=models.CASCADE)
     decision = models.BooleanField(default=False)

--- a/demo/helloworld/migrations/0001_initial.py
+++ b/demo/helloworld/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-
+import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='HelloWorldProcess',
             fields=[
-                ('process_ptr', models.OneToOneField(to='viewflow.Process', primary_key=True, parent_link=True, serialize=False, auto_created=True)),
+                ('process_ptr', models.OneToOneField(to='viewflow.Process', primary_key=True, parent_link=True, serialize=False, auto_created=True, on_delete=django.db.models.deletion.CASCADE)),
                 ('text', models.CharField(max_length=50)),
                 ('approved', models.BooleanField(default=False)),
             ],

--- a/demo/shipment/migrations/0001_initial.py
+++ b/demo/shipment/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 from django.conf import settings
-
+import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
@@ -47,8 +47,8 @@ class Migration(migrations.Migration):
                 ('carrier_quote', models.IntegerField(default=0)),
                 ('post_label', models.TextField(blank=True, null=True)),
                 ('package_tag', models.CharField(max_length=50)),
-                ('carrier', models.ForeignKey(to='shipment.Carrier', null=True)),
-                ('insurance', models.ForeignKey(to='shipment.Insurance', null=True)),
+                ('carrier', models.ForeignKey(to='shipment.Carrier', null=True, on_delete=django.db.models.deletion.CASCADE)),
+                ('insurance', models.ForeignKey(to='shipment.Insurance', null=True, on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -57,14 +57,14 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
                 ('name', models.CharField(max_length=250)),
                 ('quantity', models.IntegerField(default=1)),
-                ('shipment', models.ForeignKey(to='shipment.Shipment')),
+                ('shipment', models.ForeignKey(to='shipment.Shipment', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
             name='ShipmentProcess',
             fields=[
-                ('process_ptr', models.OneToOneField(to='viewflow.Process', primary_key=True, parent_link=True, serialize=False, auto_created=True)),
-                ('shipment', models.ForeignKey(blank=True, to='shipment.Shipment', null=True)),
+                ('process_ptr', models.OneToOneField(to='viewflow.Process', primary_key=True, parent_link=True, serialize=False, auto_created=True, on_delete=django.db.models.deletion.CASCADE)),
+                ('shipment', models.ForeignKey(blank=True, to='shipment.Shipment', null=True, on_delete=django.db.models.deletion.CASCADE)),
             ],
             options={
                 'permissions': [('can_start_request', 'Can start shipment request'), ('can_take_extra_insurance', 'Can take extra insurance'), ('can_package_goods', 'Can package goods'), ('can_move_package', 'Can move package')],

--- a/demo/shipment/models.py
+++ b/demo/shipment/models.py
@@ -29,7 +29,7 @@ class Insurance(models.Model):
 
 class Shipment(models.Model):
     shipment_no = models.CharField(max_length=50)
-    carrier = models.ForeignKey(Carrier, null=True)
+    carrier = models.ForeignKey(Carrier, null=True, on_delete=models.CASCADE)
 
     # customer
     first_name = models.CharField(max_length=150)
@@ -46,7 +46,7 @@ class Shipment(models.Model):
 
     # shipment data
     need_insurance = models.BooleanField(default=False)
-    insurance = models.ForeignKey('Insurance', null=True)
+    insurance = models.ForeignKey('Insurance', null=True, on_delete=models.CASCADE)
 
     carrier_quote = models.IntegerField(default=0)
     post_label = models.TextField(blank=True, null=True)
@@ -55,13 +55,13 @@ class Shipment(models.Model):
 
 
 class ShipmentItem(models.Model):
-    shipment = models.ForeignKey(Shipment)
+    shipment = models.ForeignKey(Shipment, on_delete=models.CASCADE)
     name = models.CharField(max_length=250)
     quantity = models.IntegerField(default=1)
 
 
 class ShipmentProcess(Process):
-    shipment = models.ForeignKey(Shipment, blank=True, null=True)
+    shipment = models.ForeignKey(Shipment, blank=True, null=True, on_delete=models.CASCADE)
 
     def is_normal_post(self):
         try:

--- a/tests/test_templatetags_base.py
+++ b/tests/test_templatetags_base.py
@@ -89,7 +89,7 @@ class TemplateTagProcessRelated(models.Model):
 
 class TemplateTagProcess(models.Model):
     content = models.CharField(max_length=50)
-    related = models.ForeignKey(TemplateTagProcessRelated)
+    related = models.ForeignKey(TemplateTagProcessRelated, on_delete=models.CASCADE)
 
 
 class ChildTemplateTagProcess(TemplateTagProcess):
@@ -98,8 +98,9 @@ class ChildTemplateTagProcess(TemplateTagProcess):
 
 class TemplateTagProcessEntity(models.Model):
     content = models.CharField(max_length=50)
-    process = models.ForeignKey(TemplateTagProcess)
-    circled_link = models.ForeignKey('TemplateTagProcessEntity', null=True)
+    process = models.ForeignKey(TemplateTagProcess, on_delete=models.CASCADE)
+    circled_link = models.ForeignKey(
+        'TemplateTagProcessEntity', null=True, on_delete=models.CASCADE)
 
 
 admin.site.register(TemplateTagProcessRelated)

--- a/viewflow/migrations/0001_initial.py
+++ b/viewflow/migrations/0001_initial.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 from django.conf import settings
+import django.db.models.deletion
 import viewflow.token
 import viewflow.fields
 
@@ -40,9 +41,9 @@ class Migration(migrations.Migration):
                 ('token', viewflow.fields.TokenField(max_length=150, default=viewflow.token.Token('start'))),
                 ('external_task_id', models.CharField(max_length=50, null=True, blank=True, db_index=True)),
                 ('owner_permission', models.CharField(max_length=50, blank=True, null=True)),
-                ('owner', models.ForeignKey(to=settings.AUTH_USER_MODEL, blank=True, null=True)),
+                ('owner', models.ForeignKey(to=settings.AUTH_USER_MODEL, blank=True, null=True, on_delete=django.db.models.deletion.CASCADE)),
                 ('previous', models.ManyToManyField(to='viewflow.Task', related_name='leading')),
-                ('process', models.ForeignKey(to='viewflow.Process')),
+                ('process', models.ForeignKey(to='viewflow.Process', on_delete=django.db.models.deletion.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/viewflow/models.py
+++ b/viewflow/models.py
@@ -79,7 +79,7 @@ class AbstractTask(models.Model):
 
     In addition, you have to define at least process foreign key field::
 
-        process = models.ForeignKey(Process)
+        process = models.ForeignKey(Process, on_delete=models.CASCADE)
 
     """
 
@@ -167,9 +167,11 @@ class Process(AbstractProcess):
 class Task(AbstractTask):
     """Default viewflow Task model."""
 
-    process = models.ForeignKey(Process)
+    process = models.ForeignKey(Process, on_delete=models.CASCADE)
 
-    owner = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, db_index=True)
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True, db_index=True,
+        on_delete=models.CASCADE)
     external_task_id = models.CharField(max_length=50, blank=True, null=True, db_index=True)
     owner_permission = models.CharField(max_length=255, blank=True, null=True)
 


### PR DESCRIPTION
Django 2.0 will require the on_delete argument. Should eliminate current deprecation warnings.
https://docs.djangoproject.com/en/1.10/ref/models/fields/#foreignkey
https://docs.djangoproject.com/en/1.10/ref/models/fields/#onetoonefield