### PR TITLE
Fix error related to importing models before their application configuration

### DIFF
--- a/viewflow/flow/views/list.py
+++ b/viewflow/flow/views/list.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.views import generic
 
-from ... import activation, models
+from ... import activation
 from .mixins import (
     LoginRequiredMixin, FlowViewPermissionMixin,
     FlowListMixin
@@ -19,6 +19,7 @@ class AllProcessListView(LoginRequiredMixin, FlowListMixin, generic.ListView):
 
     def get_queryset(self):
         """All process instances list available for the current user."""
+        from ... import models
         return models.Process.objects \
             .filter_available(self.flows, self.request.user) \
             .order_by('-created')
@@ -34,6 +35,7 @@ class AllTaskListView(LoginRequiredMixin, FlowListMixin, generic.ListView):
 
     def get_queryset(self):
         """Filtered task list."""
+        from ... import models
         return models.Task.objects.inbox(self.flows, self.request.user).order_by('-created')
 
 
@@ -47,6 +49,7 @@ class AllQueueListView(LoginRequiredMixin, FlowListMixin, generic.ListView):
 
     def get_queryset(self):
         """Filtered task list."""
+        from ... import models
         return models.Task.objects.queue(self.flows, self.request.user).order_by('-created')
 
 
@@ -60,6 +63,7 @@ class AllArchiveListView(LoginRequiredMixin, FlowListMixin, generic.ListView):
 
     def get_queryset(self):
         """All tasks from all processes assigned to the current user."""
+        from ... import models
         return models.Task.objects.archive(self.flows, self.request.user).order_by('-created')
 
 


### PR DESCRIPTION
For reference: [https://code.djangoproject.com/ticket/21719](https://code.djangoproject.com/ticket/21719)

Trying to run a test of a build of viewflow ([for conda forge](https://github.com/conda-forge/staged-recipes/pull/3058)) using the following line failed because of the issue that this commit resolves:

`python -c "import django; from django.conf import settings; settings.configure(); django.setup(); import viewflow; import viewflow.flow; import viewflow.flow.views; import viewflow.management; import viewflow.migrations; import viewflow.nodes; import viewflow.templatetags; import viewflow.frontend; import viewflow.frontend.templatetags"`

For the viewflow.flow and viewflow.flow.views packages, I received an error like so:
`RuntimeError: Model class viewflow.models.Process doesn't declare an explicit ap
p_label and isn't in an application in INSTALLED_APPS.`

This commit resolves the above error.