### PR TITLE
Docstring fixes

### DIFF
--- a/viewflow/__init__.py
+++ b/viewflow/__init__.py
@@ -27,12 +27,12 @@ class ThisObject(object):
 class This(object):
     """Helper for building forward referenced flow task.
 
-    The rationaly is ability to specify referencies to the class
-    attribute and methods before they declated.
+    The rationale is ability to specify references to the class
+    attributes and methods before they are declared.
 
     `this` is like a `self` but for the class body.
 
-    The referencies are resolved by the metaclass at the end of the
+    The references are resolved by the metaclass at the end of the
     flow construction.
 
     Example::

--- a/viewflow/activation.py
+++ b/viewflow/activation.py
@@ -109,11 +109,11 @@ class Activation(object):
     """
     Base class for flow task activations.
 
-    Activation responsible for flow task state management and persistance
+    Activation is responsible for flow task state management and persistance.
 
-    Each activation status chages restricted by a simple finite state automata
+    Each activation status changes are restricted by a simple finite state automata.
 
-    Base class enshures that all tasks could be undone or cancelled.
+    Base class ensures that all tasks can be undone or cancelled.
 
     .. graphviz::
 
@@ -129,10 +129,10 @@ class Activation(object):
     status = fsm.State()
 
     def __init__(self, *args, **kwargs):
-        """Instanciate an activation.
+        """Instantiate an activation.
 
         The activation should be avaliable to instantiate without
-        any agruments.
+        any arguments.
         """
         self.flow_class, self.flow_task = None, None
         self.process, self.task = None, None
@@ -160,7 +160,7 @@ class Activation(object):
         """
         Perform activation action inside a transaction.
 
-        Handle and propagate exception depends on actvation context state
+        Handle and propagate exception depending on activation context state.
         """
         @contextmanager
         def guard():
@@ -193,7 +193,7 @@ class Activation(object):
         """
         Undo the task.
 
-        If flow class have `[task_name]_undo(self, activation)` method it would be called
+        If flow class has `[task_name]_undo(self, activation)` method, it will be called.
         """
         self.task.finished = None
         self.task.save()
@@ -496,7 +496,7 @@ class AbstractGateActivation(Activation):
     @Activation.status.transition(source=STATUS.NEW)
     def perform(self):
         """
-        Calculate the next codes and activates it.
+        Calculate the next node and activate it.
 
         .. seealso::
             :data:`viewflow.signals.task_started`
@@ -598,7 +598,7 @@ class AbstractJobActivation(Activation):
         """
         Run task asynchronously.
 
-        Subclasses should override that method
+        Subclasses should override that method.
         """
         raise NotImplementedError
 

--- a/viewflow/activation.py
+++ b/viewflow/activation.py
@@ -55,11 +55,11 @@ def all_leading_canceled(activation):
 class Context(object):
     """Thread-local activation context, dynamically scoped.
 
-    :keyword propagate_exception: If True on activation fails
-                                  exception would be propagated to
-                                  previous activalion, if False,
-                                  current task activation would be
-                                  marked as failed
+    :keyword propagate_exception: If True, on activation failure
+                                  exception will be propagated to
+                                  previous activation. If False,
+                                  current task activation will be
+                                  marked as failed.
 
 
     Usage ::

--- a/viewflow/decorators.py
+++ b/viewflow/decorators.py
@@ -34,8 +34,8 @@ def flow_func(func):
     """
     Decorator for flow functions.
 
-    Expect function that gets activation instance as the first parameter,
-    Returns function that expects task instance as the first parameter instead
+    Expects function that gets activation instance as the first parameter.
+    Returns function that expects task instance as the first parameter instead.
     """
     @transaction.atomic
     @functools.wraps(func)
@@ -57,11 +57,11 @@ def flow_job(func):
     Decorator that prepares celery task for execution.
 
     Makes celery job function with the following signature
-    `(flow_task-strref, process_pk, task_pk, **kwargs)`
+    `(flow_task-strref, process_pk, task_pk, **kwargs)`.
 
-    Expects actual celery job function which has the following signature `(activation, **kwargs)`
+    Expects actual celery job function which has the following signature `(activation, **kwargs)`.
     If celery task class implements activation interface, job function is
-    called without activation instance `(**kwargs)`
+    called without activation instance `(**kwargs)`.
 
     Process instance is locked only before and after the function execution.
     Please avoid any process state modification during the celery job.
@@ -160,8 +160,8 @@ def flow_start_view(view):
     """
     Decorator for start views, creates and initializes start activation.
 
-    Expects view with the signature `(request, **kwargs)`
-    Returns view with the signature `(request, flow_class, flow_task, **kwargs)`
+    Expects view with the signature `(request, **kwargs)`.
+    Returns view with the signature `(request, flow_class, flow_task, **kwargs)`.
     """
     @transaction.atomic
     @functools.wraps(view)
@@ -191,8 +191,8 @@ def flow_view(view):
     """
     Decorator that locks and runs the flow view in transaction.
 
-    Expects view with the signature `(request, **kwargs)`
-    Returns view with the signature `(request, flow_class, flow_task, process_pk, task_pk, **kwargs)
+    Expects view with the signature `(request, **kwargs)`.
+    Returns view with the signature `(request, flow_class, flow_task, process_pk, task_pk, **kwargs)`.
     """
     @transaction.atomic
     @functools.wraps(view)

--- a/viewflow/exceptions.py
+++ b/viewflow/exceptions.py
@@ -1,5 +1,5 @@
 class FlowRuntimeError(Exception):
-    """Unrecovable flow runtime error."""
+    """Unrecoverable flow runtime error."""
 
 
 class FlowLockFailed(Exception):

--- a/viewflow/managers.py
+++ b/viewflow/managers.py
@@ -108,7 +108,7 @@ class ProcessQuerySet(QuerySet):
         return super(ProcessQuerySet, self).filter(*args, **kwargs)
 
     def coerce_for(self, flow_classes):
-        """Return subclass instancess of the Task."""
+        """Return subclass instances of the Task."""
         self._coerced = True
 
         flow_classes = list(flow_classes)
@@ -176,7 +176,7 @@ class TaskQuerySet(QuerySet):
         return super(TaskQuerySet, self).filter(*args, **kwargs)
 
     def coerce_for(self, flow_classes):
-        """Return subclass instancess of the Task."""
+        """Return subclass instances of the Task."""
         self._coerced = True
         flow_classes = list(flow_classes)
 
@@ -219,7 +219,7 @@ class TaskQuerySet(QuerySet):
         return queryset.filter(owner=user, finished__isnull=False)
 
     def filter_available(self, flow_classes, user):
-        """List of task available to view for the user."""
+        """List of tasks available to view for the user."""
         return self.model.objects.coerce_for(_available_flows(flow_classes, user))
 
     def inbox(self, flow_classes, user):


### PR DESCRIPTION
I found some language errors (spelling, punctuation etc.) while reading the documentation on [viewflow.io](http://docs.viewflow.io/) and I would like to help by fixing them. Some are obvious typos, while others (e.g. punctuation, grammar) might be a little subjective, so please check if you agree with my changes.