### PR TITLE
ns_map documentation fix

### DIFF
--- a/viewflow/flow/views/mixins.py
+++ b/viewflow/flow/views/mixins.py
@@ -104,7 +104,7 @@ class FlowListMixin(object):
         """
         Instantiate a view.
 
-        :param ns_map: Dict{'flow_namespace': flow_class}
+        :param ns_map: Dict{flow_class : 'flow_namespace'}
         """
         self.ns_map = kwargs.get('ns_map', {})
         super(FlowListMixin, self).__init__(*args, **kwargs)


### PR DESCRIPTION
FlowListMixin requires ns_map to be a dictionary in the format Dict{flow_class : 'flow_namespace'}, not Dict{'flow_namespace': flow_class} as the current documentation asserts.