### PR TITLE
Issue 248 - update the start times on assign

### DIFF
--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -93,12 +93,15 @@ class Test(TestCase):
         # check assign/reassin flow
         act.assign(Test.UserStub())
         self.assertEqual(act.task.status, STATUS.ASSIGNED)
+        self.assertIsNotNone(act.task.started)
 
         act.reassign(Test.UserStub())
         self.assertEqual(act.task.status, STATUS.ASSIGNED)
+        self.assertIsNotNone(act.task.started)
 
         act.unassign()
         self.assertEqual(act.task.status, STATUS.NEW)
+        self.assertIsNone(act.task.started)
 
         # execute
         act.assign(Test.UserStub())

--- a/viewflow/activation.py
+++ b/viewflow/activation.py
@@ -338,12 +338,14 @@ class ViewActivation(Activation):
         """Assign user to the task."""
         if user:
             self.task.owner = user
+        self.task.started = now()
         self.task.save()
 
     @Activation.status.transition(source=STATUS.ASSIGNED, target=STATUS.NEW)
     def unassign(self):
         """Remove user from the task assignment."""
         self.task.owner = None
+        self.task.started = None
         self.task.save()
 
     @Activation.status.transition(source=STATUS.ASSIGNED)
@@ -351,6 +353,7 @@ class ViewActivation(Activation):
         """Reassign to another user."""
         if user:
             self.task.owner = user
+        self.task.started = now()
         self.task.save()
 
     @Activation.status.transition(source=STATUS.ASSIGNED, target=STATUS.PREPARED)


### PR DESCRIPTION
In this PR, I am updating the start times when a user assigns/unassigns or reassigns a task.  

When a user assigns himself a task he's working on, we should set the start time.
While using the viewflow library, we wanted to build something that auto-unassigns after sometime of no progress on the project, setting the start time should help with auto-unassigning. We noticed there was a similar request (#73).