### PR TITLE
docs: Fix simple typo, propogation -> propagation

### DIFF
--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -136,7 +136,7 @@ class Test(TestCase):
         # by default gate exceptions are propogated
         self.assertRaises(ValueError, act.perform)
 
-        # disable gate error propogation
+        # disable gate error propagation
         with activation.Context(propagate_exception=False):
             act.perform()
             self.assertEqual(act.task.status, STATUS.ERROR)
@@ -179,7 +179,7 @@ class Test(TestCase):
         self.assertEqual(act.task.status, STATUS.ASSIGNED)
         self.assertRaises(ValueError, act.schedule)
 
-        # disable error propogation
+        # disable error propagation
         with activation.Context(propagate_exception=False):
             act.schedule()
             act.retry()

--- a/tests/test_flow_func.py
+++ b/tests/test_flow_func.py
@@ -137,7 +137,7 @@ class Test(TestCase):
         # by default errors are propogated
         self.assertRaises(ValueError, act.perform)
 
-        # disable gate error propogation
+        # disable gate error propagation
         with Context(propagate_exception=False):
             act.perform()
             self.assertEqual(act.task.status, STATUS.ERROR)


### PR DESCRIPTION
There is a small typo in tests/test_activation.py, tests/test_flow_func.py.

Should read `propagation` rather than `propogation`.

