### PR TITLE
Fix boolean condition in viewflow/flow/views/task.py

### DIFF
--- a/viewflow/flow/views/task.py
+++ b/viewflow/flow/views/task.py
@@ -170,7 +170,7 @@ class AssignTaskView(MessageUserMixin, generic.TemplateView):
             <button type="submit" name="_continue">Assign and continue on this process</button>
             <button type="submit" name="_assign">Assign</button>
         """
-        if '_assign' or '_continue' in request.POST:
+        if ('_assign' in request.POST) or ('_continue' in request.POST):
             self.activation.assign(self.request.user)
             self.success(_('Task {task} has been assigned'))
             return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
Hi there!
While [scanning a bunch of Python code](https://semgrep.live/scan/e0f761b3-0027-4751-acca-4ae68c726bde), I noticed this issue where strings were being used with a boolean operator in a suspect way.

In Python, using string literals with boolean operators can be tricky. Check out this snippet for the behavior of strings and boolean operators:

```python
>>> d = {'a': 1, 'b': 2}
>>> 'a' and 'b' in d
True
>>> 'a' in d
True
>>> 'a' and 'b'
'b'
>>> 'b' in d
True
>>> 'b' and 'c' in d
False
>>> 'c' and 'b' in d
True
>>> 'zip' or 'pkg'
'zip'
```

That means, in `viewflow/flow/views/task.py` the if statement checking for `'_assign' or '_continue' in request.POST` would only use `'_assign'` to satisfy the condition. I can't imagine this causing major issues in your code, but this PR fixes it anyway.

Hope this helps! If you're interested in scanning more of your code, check out https://semgrep.live!
Cheers!