### PR TITLE
Update 0002_fsmchange.py to allow uninstall

### DIFF
--- a/viewflow/migrations/0002_fsmchange.py
+++ b/viewflow/migrations/0002_fsmchange.py
@@ -29,6 +29,6 @@ class Migration(migrations.Migration):
             preserve_default=True,
         ),
         migrations.RunPython(
-            update_status
+            update_status, migrations.RunPython.noop
         )
     ]


### PR DESCRIPTION
Currently this migration is irreversible and viewflow cannot be fully uninstalled.  This tweak allows complete migration backwards with `python manage.py migrate viewflow zero`