### PR TITLE
Raise exception to avoid redirect loop

### DIFF
--- a/viewflow/flow/views/mixins.py
+++ b/viewflow/flow/views/mixins.py
@@ -15,8 +15,8 @@ class LoginRequiredMixin(object):
     def dispatch(self, *args, **kwargs):  # noqa D102
         return super(LoginRequiredMixin, self).dispatch(*args, **kwargs)
 
-
-class FlowViewPermissionMixin(LoginRequiredMixin):
+@method_decorator(login_required, name="dispatch")
+class FlowViewPermissionMixin:
     """Mixin for flow views, check the view permission."""
 
     def dispatch(self, *args, **kwargs):  # noqa D102
@@ -25,7 +25,8 @@ class FlowViewPermissionMixin(LoginRequiredMixin):
             super(FlowViewPermissionMixin, self).dispatch)(*args, **kwargs)
 
 
-class FlowManagePermissionMixin(LoginRequiredMixin):
+@method_decorator(login_required, name="dispatch")
+class FlowManagePermissionMixin:
     """Mixin for flow flow views, check flow manage permission."""
 
     def dispatch(self, *args, **kwargs):  # noqa D102
@@ -34,7 +35,8 @@ class FlowManagePermissionMixin(LoginRequiredMixin):
             super(FlowManagePermissionMixin, self).dispatch)(*args, **kwargs)
 
 
-class FlowTaskManagePermissionMixin(LoginRequiredMixin):
+@method_decorator(login_required, name="dispatch")
+class FlowTaskManagePermissionMixin:
     """Mixin for flow task views, check flow manage permission."""
 
     def dispatch(self, *args, **kwargs):  # noqa D102

--- a/viewflow/flow/views/mixins.py
+++ b/viewflow/flow/views/mixins.py
@@ -16,31 +16,31 @@ class LoginRequiredMixin(object):
         return super(LoginRequiredMixin, self).dispatch(*args, **kwargs)
 
 
-class FlowViewPermissionMixin(object):
+class FlowViewPermissionMixin(LoginRequiredMixin):
     """Mixin for flow views, check the view permission."""
 
     def dispatch(self, *args, **kwargs):  # noqa D102
         self.flow_class = kwargs['flow_class']
-        return permission_required(self.flow_class._meta.view_permission_name)(
+        return permission_required(self.flow_class._meta.view_permission_name, raise_exception=True)(
             super(FlowViewPermissionMixin, self).dispatch)(*args, **kwargs)
 
 
-class FlowManagePermissionMixin(object):
+class FlowManagePermissionMixin(LoginRequiredMixin):
     """Mixin for flow flow views, check flow manage permission."""
 
     def dispatch(self, *args, **kwargs):  # noqa D102
         self.flow_class = kwargs['flow_class']
-        return permission_required(self.flow_class._meta.manage_permission_name)(
+        return permission_required(self.flow_class._meta.manage_permission_name, raise_exception=True)(
             super(FlowManagePermissionMixin, self).dispatch)(*args, **kwargs)
 
 
-class FlowTaskManagePermissionMixin(object):
+class FlowTaskManagePermissionMixin(LoginRequiredMixin):
     """Mixin for flow task views, check flow manage permission."""
 
     def dispatch(self, *args, **kwargs):  # noqa D102
         self.flow_task = kwargs['flow_task']
         self.flow_class = self.flow_task.flow_class
-        return permission_required(self.flow_class._meta.manage_permission_name)(
+        return permission_required(self.flow_class._meta.manage_permission_name, raise_exception=True)(
             super(FlowTaskManagePermissionMixin, self).dispatch)(*args, **kwargs)
 
 


### PR DESCRIPTION
With default `raise_exception = False` , failed permission redirects the user to login page. But since user is already logged in, a redirect loop sets in. With `raise_exception=True` user is shown a 403 error. LoginRequiredMixin ensures user is logged in before checking permissions.

I do not now how to test this change, or if it will cause other issues. I did not want the redirect loop in my project, I so I have to change the views that check permissions.