### PR TITLE
This change allow to have primary keys with db_column different to field name.

### DIFF
--- a/viewflow/fields.py
+++ b/viewflow/fields.py
@@ -9,7 +9,7 @@ import datetime
 import decimal
 import json
 import uuid
-from typing import List
+from typing import List, Tuple
 from django.db import DEFAULT_DB_ALIAS, models, router
 from django.db.models import signals
 from django.db.models.sql.where import WhereNode, AND


### PR DESCRIPTION
This error was observed on admin views due to admin list views add a order_by('-pk') to the queryset. The conversion to pk to column use self.column and if self.column is a field name then it raise a column not found error at db level.