### PR TITLE
Add support for blank FileField in Process

### DIFF
--- a/viewflow/frontend/templates/viewflow/flow/process_data.html
+++ b/viewflow/frontend/templates/viewflow/flow/process_data.html
@@ -13,7 +13,7 @@
             <dd>
                 {% if value is True %}{% trans 'Yes' %}{% else %}
                 {% if value is False %}{% trans 'No' %}{% else %}
-                {% if value.url %}<a href="{{ value.url }}" target="_blank">{{ value.name }}</a>{% else %}
+                {% if value and value.url %}<a href="{{ value.url }}" target="_blank">{{ value.name }}</a>{% else %}
                 {{ value }}{% endif %}{% endif %}{% endif %}
             </dd>
             {% endfor %}


### PR DESCRIPTION
Currently, trying to render the template `process_data.html` when the Process contains a FileField with `blank=True` raises a `ValueError: The 'document' attribute has no file associated with it.`, where `document` is the name of the field.