### PR TITLE
Fix AllArchive/ProcessListView.process_summary

### DIFF
--- a/viewflow/frontend/views.py
+++ b/viewflow/frontend/views.py
@@ -275,7 +275,7 @@ class AllArchiveListView(FlowListMixin,
     def process_summary(self, task):
         process_url = frontend_url(self.request, self.get_process_url(task.process), back_link='here')
         return mark_safe('<a href="{}">{}</a>'.format(
-            process_url, task.flow_process.summary()))
+            process_url, task.flow_process.summary))
     process_summary.short_description = _('Process Summary')
 
     def get_queryset(self):
@@ -313,7 +313,7 @@ class ProcessListView(FlowViewPermissionMixin,
     def process_summary(self, process):
         return mark_safe('<a href="{}">{}</a>'.format(
             self.get_process_link(process),
-            process.summary())
+            process.summary)
         )
     process_summary.short_description = 'Summary'
 


### PR DESCRIPTION
## Problem
When I view "Participated" (AllArchiveListView) or "Processes" (ProcessListView), the Exception `str object ist not callable` is thrown when `process_summary` calls `task.flow_process.summary()` or `process.summary()`, respectively.

## Fix
Dropping the `()` fixes this problem.
There might be other occurrences of a `summary()` getting called as a function which I haven't hit yet and can't produce the faulty behaviour for.

## Discussion
I have been a fan of django-fsm for a decade, but am quite new to viewflow. I'm just building my first workflows and must be doing something quite wrong, seeing no issue has been raised about this so far.
I'd like to submit this PR as a worked example for my problem with a fix for the unlikely case that this is a valid bug.