### PR TITLE
Improve model generic FK type compatibility

### DIFF
--- a/viewflow/workflow/migrations/0015_alter_process_task_artifact_and_seed_object_id.py
+++ b/viewflow/workflow/migrations/0015_alter_process_task_artifact_and_seed_object_id.py
@@ -1,0 +1,112 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+def remove_task_check_constraints(apps, schema_editor):
+    Task = apps.get_model("viewflow", "Task")
+
+    schema_editor.remove_constraint(Task, "check_artifact_object_id")
+    schema_editor.remove_constraint(Task, "check_seed_object_id")
+
+
+def add_task_check_constraints(apps, schema_editor):
+    Task = apps.get_model("viewflow", "Task")
+
+    schema_editor.add_constraint(
+        Task,
+        models.CheckConstraint(
+            name="check_artifact_object_id",
+            condition=Q(artifact_object_id__gte=0),
+        )
+    )
+    schema_editor.add_constraint(
+        Task,
+        models.CheckConstraint(
+            name="check_seed_object_id",
+            condition=Q(seed_object_id__gte=0),
+        )
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("viewflow", "0014_alter_process_parent_task"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="process",
+                    name="artifact_object_id",
+                    field=models.CharField(blank=True, max_length=36, null=True),
+                ),
+                migrations.AlterField(
+                    model_name="process",
+                    name="seed_object_id",
+                    field=models.CharField(blank=True, max_length=36, null=True),
+                ),
+                migrations.AlterField(
+                    model_name="task",
+                    name="artifact_object_id",
+                    field=models.CharField(blank=True, max_length=36, null=True),
+                ),
+                migrations.AlterField(
+                    model_name="task",
+                    name="seed_object_id",
+                    field=models.CharField(blank=True, max_length=36, null=True),
+                ),
+            ],
+            database_operations=[
+                # Not all databases support altering the column type for
+                # columns that are part of an index, so remove the index
+                # first...
+                migrations.RemoveIndex(
+                    model_name="process",
+                    name="viewflow_pr_artifac_64c8a3_idx",
+                ),
+
+                # ... then alter the columns ...
+                migrations.AlterField(
+                    model_name="process",
+                    name="artifact_object_id",
+                    field=models.CharField(blank=True, max_length=36, null=True),
+                ),
+                migrations.AlterField(
+                    model_name="process",
+                    name="seed_object_id",
+                    field=models.CharField(blank=True, max_length=36, null=True),
+                ),
+
+                # ... and recreate afterward.
+                migrations.AddIndex(
+                    model_name="process",
+                    index=models.Index(
+                        fields=["artifact_content_type", "artifact_object_id"],
+                        name="viewflow_pr_artifac_64c8a3_idx",
+                    ),
+                ),
+
+                # Not all databases support altering the column type for
+                # columns with constraints, so remove the constraints first ...
+                migrations.RunPython(remove_task_check_constraints),
+
+                # ... then alter the columns ...
+                migrations.AlterField(
+                    model_name="task",
+                    name="artifact_object_id",
+                    field=models.CharField(blank=True, max_length=36, null=True),
+                ),
+
+                migrations.AlterField(
+                    model_name="task",
+                    name="seed_object_id",
+                    field=models.CharField(blank=True, max_length=36, null=True),
+                ),
+
+                # ... and recreate afterward.
+                migrations.RunPython(add_task_check_constraints),
+            ],
+        ),
+    ]

--- a/viewflow/workflow/models.py
+++ b/viewflow/workflow/models.py
@@ -257,7 +257,7 @@ class Process(AbstractProcess):
         related_name="+",
         to=ContentType,
     )
-    seed_object_id = models.PositiveIntegerField(null=True, blank=True)
+    seed_object_id = models.CharField(max_length=36, null=True, blank=True)
 
     # process artifact reference
     artifact = GenericForeignKey("artifact_content_type", "artifact_object_id")
@@ -269,7 +269,7 @@ class Process(AbstractProcess):
         related_name="+",
         to=ContentType,
     )
-    artifact_object_id = models.PositiveIntegerField(null=True, blank=True)
+    artifact_object_id = models.CharField(max_length=36, null=True, blank=True)
 
     class Meta:  # noqa D101
         ordering = ["-created"]
@@ -301,7 +301,7 @@ class Task(AbstractTask):
         related_name="+",
         to=ContentType,
     )
-    seed_object_id = models.PositiveIntegerField(null=True, blank=True)
+    seed_object_id = models.CharField(max_length=36, null=True, blank=True)
 
     # task artifact reference
     artifact = GenericForeignKey("artifact_content_type", "artifact_object_id")
@@ -314,7 +314,7 @@ class Task(AbstractTask):
         to=ContentType,
     )
 
-    artifact_object_id = models.PositiveIntegerField(null=True, blank=True)
+    artifact_object_id = models.CharField(max_length=36, null=True, blank=True)
 
     class Meta:  # noqa D101
         verbose_name = _("Task")


### PR DESCRIPTION
# Problem

I'm using CockroachDB which prefers primary keys of type UUID. The Process and Task models defines the generic foreign key object ID fields as integer types. This causes an error because UUID's can't be coerced into integers.


# Solution

As Described in the Django docs:

> Primary key type compatibility
> 
> The “object_id” field doesn’t have to be the same type as the primary key fields on the related models, but their primary key values must be coercible to the same type as the “object_id” field by its [get_db_prep_value()](https://docs.djangoproject.com/en/5.1/ref/models/fields/#django.db.models.Field.get_db_prep_value) method.
> 
> For example, if you want to allow generic relations to models with either [IntegerField](https://docs.djangoproject.com/en/5.1/ref/models/fields/#django.db.models.IntegerField) or [CharField](https://docs.djangoproject.com/en/5.1/ref/models/fields/#django.db.models.CharField) primary key fields, you can use [CharField](https://docs.djangoproject.com/en/5.1/ref/models/fields/#django.db.models.CharField) for the “object_id” field on your model since integers can be coerced to strings by [get_db_prep_value()](https://docs.djangoproject.com/en/5.1/ref/models/fields/#django.db.models.Field.get_db_prep_value).

Change the object ID fields to a CharField with an length of 36. This fits both UUID(4)'s and big integers as a string. All values are automatically coerced into a string. Additionally, I changed the generated migration to drop and recreate the index, since CockroachDB (and maybe other databases do to) don't support altering the data type for indexed fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated data types for `seed_object_id` and `artifact_object_id` fields in both `Process` and `Task` classes to allow for more flexible data handling.

- **Bug Fixes**
	- Removed and recreated an index to improve database performance related to the `process` model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->