### PR TITLE
Fix: Handle falsy state values correctly in state transitions

### DIFF
--- a/viewflow/fsm/base.py
+++ b/viewflow/fsm/base.py
@@ -161,7 +161,7 @@ class TransitionBoundMethod:
                 )
 
             self.target_state = transition.target
-            if self.target_state:
+            if self.target_state is not None:
                 self.parent._state.set(self.parent._instance, self.target_state)
 
         def __exit__(
@@ -377,10 +377,7 @@ class State:
         """Get the state from the underline class instance."""
         if self._getter:
             value = self._getter(instance)
-            if self._default:
-                return value if value else self._default
-            else:
-                return value
+            return self._default if self._default and value is None else value
         return getattr(instance, self.propname, self._default)
 
     def set(self, instance: object, value: StateValue) -> None:


### PR DESCRIPTION
This pull request addresses an issue with how `viewflow/viewflow` handles state transitions in finite state machines (FSM) when the state field contains valid falsy values (e.g., `0`).

Currently:
- When retrieving the state, `viewflow` falls back to the default state if the current state evaluates to `False`. This incorrectly includes valid falsy states such as `0`, which are part of the FSM choices.
- When setting the state during a transition, `viewflow` skips updating the state if the target state evaluates to `False`. This also incorrectly skips valid falsy states.

Proposed changes:
-  Update the logic to check if the state is `None` instead of relying on falsy/truthy checks. This ensures that valid falsy values like `0` are handled correctly while still allowing the fallback behavior for `None`.

Changes Made:
1. Updated the state retrieval logic to fallback to the default state **only** if the current state is `None`.
2. Updated the state assignment logic to ensure the state is updated for all valid values, excluding only `None`.


**Notes:**
This change ensures that state transitions correctly handle all valid states, including those with falsy values, aligning the behavior with the expected FSM design in Django applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved state transition handling and logic in the state management system
	- Enhanced clarity and readability of state value retrieval mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->