### PR TITLE
Resolve Python testing warnings

### DIFF
--- a/tests/contrib/test_contrib_auth.py
+++ b/tests/contrib/test_contrib_auth.py
@@ -25,7 +25,7 @@ class Test(TestCase):
         view.setup(request)
 
         response = view.post(request)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertIn("/media/avatars/", auth.get_user_avatar_url(self.admin))
 
     @tag("integration")

--- a/tests/workflow/test_nodes__view.py
+++ b/tests/workflow/test_nodes__view.py
@@ -67,7 +67,7 @@ class Test(TestCase):  # noqa: D101
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(execute_url, {"_continue": 1})
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         # check
         process.refresh_from_db()


### PR DESCRIPTION
# PR Summary
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test assertions to use the correct and current assertion method, improving code quality without affecting test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->