### PR TITLE
fsm/typing: relax Condition/Permission callable param to Any

### DIFF
--- a/viewflow/fsm/typing.py
+++ b/viewflow/fsm/typing.py
@@ -13,7 +13,16 @@ if TYPE_CHECKING:
 
 UserModel = Any
 StateValue = Any
-Condition = Union[ThisObject, Callable[[object], bool]]
-Permission = Union[ThisObject, Callable[[object, Any], bool]]
+# Note: Callable parameter is ``Any`` (rather than ``object``) so a typed
+# predicate that takes a specific flow class — e.g.
+# ``Callable[[Publication], bool]`` — type-checks under pyright/mypy at
+# the registration site. With ``[object]``, parameter contravariance
+# rejects narrower predicates (a function that only accepts
+# ``Publication`` is *not* substitutable where ``Callable[[object], bool]``
+# is expected). ``Any`` is gradually typed, so any concrete-param
+# predicate flows through cleanly. Runtime behavior is unchanged —
+# predicates are still invoked with the flow instance.
+Condition = Union[ThisObject, Callable[[Any], bool]]
+Permission = Union[ThisObject, Callable[[Any, Any], bool]]
 StateTransitions = Mapping["TransitionMethod", List["Transition"]]
 TransitionFunction = Callable[..., Any]


### PR DESCRIPTION
## Summary

`Condition` and `Permission` in `viewflow.fsm.typing` are declared with
`Callable[[object], bool]`. Under PEP 484 parameter contravariance, this
rejects narrower predicates such as `Callable[[Publication], bool]` at
the registration site:

```python
class _Publication:
    stage = State(ReviewState, default=ReviewState.NEW)

    @stage.transition(
        source=ReviewState.NEW,
        target=ReviewState.PUBLISHED,
        conditions=[is_published],   # def is_published(p: _Publication) -> bool: ...
    )
    def publish(self): ...
```

```
error: Argument of type "list[(p: _Publication) -> bool]" cannot be
       assigned to parameter "conditions" of type "List[Condition] | None"
```

The only way to satisfy `[object]` today is to widen the predicate's
parameter to `object` (losing attribute-access type checks inside the
body) or scatter `# type: ignore` at every registration site.

This PR changes the callable parameter to `Any`. PEP 484 treats `Any`
as bidirectional / gradually typed, so any concrete-param callable
flows through to `Callable[[Any], bool]` without a cast or wrapper.

## Why this is correct

Looking at `Transition.conditions_met` in `viewflow/fsm/base.py`:

```python
def conditions_met(self, instance: object) -> bool:
    conditions = [...]
    return all(map(lambda condition: condition(instance), conditions))
```

The runtime invocation already passes the flow class instance to each
condition — there's no actual `object` constraint at call time, just an
imprecise static annotation. Relaxing to `Any` matches what the runtime
does without changing behavior.

`Permission` gets the same treatment for consistency (its first
parameter is the flow instance; the second is the user model, already
`Any`).

## Backward compatibility

100% compatible:
- Existing `[object]`-param predicates still satisfy `[Any]` (Any is
  wider).
- Existing untyped lambdas (the most common pattern in viewflow tests)
  are unaffected.
- Runtime behavior is identical — this is a pure type-annotation change.

## Tested

`./manage.py test --exclude-tag=selenium --exclude-tag=integration`
passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type annotations for condition and permission predicates to enhance static type checker compatibility. Updates allow predicates accepting specific flow class implementations to be properly recognized at registration, enabling more flexible and type-safe flow definitions with improved IDE support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->