### PR TITLE
Add py.typed marker (PEP 561 compliance)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
 include LICENSE
-include LICENSE_EXCEPTION 
+include LICENSE_EXCEPTION
 include MANIFEST.in
 include README.rst
+include viewflow/py.typed
 recursive-include viewflow/templates *
 recursive-include viewflow/locale *
 recursive-include viewflow/static *

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     long_description=README,
     packages=setuptools.find_packages(exclude=["tests*"]),
+    package_data={"viewflow": ["py.typed"]},
     python_requires=">=3.10",
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
## Summary

viewflow has inline type annotations throughout (`State`, `Transition`,
the `@transition` decorator signatures, `Condition`/`Permission` aliases,
etc.), but ships no `py.typed` marker file. Per PEP 561, type checkers
**ignore inline annotations from packages that don't declare themselves
typed** — so pyright (and mypy without ad-hoc namespace overrides)
currently treats every viewflow import as unresolved:

\`\`\`
Import \"viewflow.fsm\" could not be resolved [reportMissingImports]
\`\`\`

That means none of the type annotations the project already has are
visible to downstream code.

## Change

Adds an empty `viewflow/py.typed` file (the marker is its **presence**;
contents don't matter per PEP 561). Wires it into the distribution via
both `MANIFEST.in` (sdist) and `setup.py`'s `package_data` (wheel) so
it ships in both build artifacts.

## Effect

Zero code change. After this lands, type checkers honor the existing
annotations — no extra typing work required.

## Relation to #501

#501 fixed `Condition` / `Permission` callable parameter contravariance
so typed predicates like \`Callable[[Publication], bool]\` flow through
to \`state.transition(conditions=...)\`. That fix has **no observable
effect under pyright until py.typed lands**, because pyright doesn't
read viewflow's annotations otherwise. Both PRs together unlock typed
viewflow usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved type-checking support by including type metadata in package distribution, enabling better IDE and type-checker integration for library users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->