### PR TITLE
Made default briefs for Task and Process use localized status instead of raw string value.

### DIFF
--- a/viewflow/workflow/models.py
+++ b/viewflow/workflow/models.py
@@ -58,7 +58,7 @@ class AbstractProcess(models.Model):
             template_content = self.flow_class.process_description
 
         if not template_content:
-            template_content = "{{ flow_class.process_title }} - {{ process.status }}"
+            template_content = "{{ flow_class.process_title }} - {{ process.get_status_display }}"
 
         return Template(force_str(template_content)).render(
             Context({"process": self.coerced, "flow_class": self.flow_class})
@@ -206,7 +206,7 @@ class AbstractTask(models.Model):
             template_content = self.flow_task.task_title
 
         if not template_content:
-            template_content = "{{ flow_task }}/{{ task.status }}"
+            template_content = "{{ flow_task }}/{{ task.get_status_display }}"
 
         return Template(force_str(template_content)).render(
             Context(


### PR DESCRIPTION
Made default template use `.get_status_display` instead of just `.status` to allow for better control over how the status of a flow is displayed via localization files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status information now displays in human-readable format instead of technical values, making process and task states easier to understand at a glance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/viewflow/viewflow/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->